### PR TITLE
A partial travis config file to run the build and deploy releases to atlas.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 install:
   - wget --no-check-certificate --output-document packer.zip $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip
   - unzip -d packer packer.zip
-  - export PATH_$PATH:$PWD/packer
+  - export PATH=$PATH:$PWD/packer
 
 script:
   - packer build template.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - ATLAS_TOKEN=?? # use secure:
 
 install:
+  - sudo apt-get install virtualbox
   - wget --no-check-certificate --output-document packer.zip $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip
   - unzip -d packer packer.zip
   - export PATH=$PATH:$PWD/packer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: ruby
+rvm:
+  - 2.2
+
+env:
+  global:
+    - PACKER_DOWNLOAD=https://dl.bintray.com/mitchellh/packer
+    - ATLAS_DOWNLOAD=https://github.com/hashicorp/atlas-upload-cli/releases/download
+    - ATLAS_TOKEN=?? # use secure:
+
+install:
+  - bundle install
+  - wget --no-check-certificate \
+  -   --output-document packer.zip
+  -   $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip
+  - unzip -d packer packer.zip
+  - export PATH_$PATH:$PWD/packer
+
+script:
+  - packer build template.json
+
+before_deploy:
+  - wget --no-check-certificate \
+  -   --output-document atlas-upload-cli.tar.gz \
+  -   $ATLAS_DOWNLOAD/v0.2.0/atlas-upload-cli_0.2.0_linux_386.tar.gz
+  - tar xzf atlas-upload-cli.tar.gz -C atlas-upload-cli
+  - export PATH=$PATH:/$PWD/atlas-upload-cli
+
+deploy:
+  provider: script
+  script: atlas-upload -include=*.box oxdi/nixos .
+  skip_cleanup: true
+  on:
+    tags: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - ATLAS_TOKEN=?? # use secure:
 
 install:
-  - bundle install
   - wget --no-check-certificate \
   -   --output-document packer.zip
   -   $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ env:
     - ATLAS_TOKEN=?? # use secure:
 
 install:
-  - wget --no-check-certificate \
-  -   --output-document packer.zip
-  -   $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip
+  - wget --no-check-certificate --output-document packer.zip $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip
   - unzip -d packer packer.zip
   - export PATH_$PATH:$PWD/packer
 
@@ -19,9 +17,7 @@ script:
   - packer build template.json
 
 before_deploy:
-  - wget --no-check-certificate \
-  -   --output-document atlas-upload-cli.tar.gz \
-  -   $ATLAS_DOWNLOAD/v0.2.0/atlas-upload-cli_0.2.0_linux_386.tar.gz
+  - wget --no-check-certificate --output-document atlas-upload-cli.tar.gz $ATLAS_DOWNLOAD/v0.2.0/atlas-upload-cli_0.2.0_linux_386.tar.gz
   - tar xzf atlas-upload-cli.tar.gz -C atlas-upload-cli
   - export PATH=$PATH:/$PWD/atlas-upload-cli
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ env:
     - ATLAS_DOWNLOAD=https://github.com/hashicorp/atlas-upload-cli/releases/download
     - ATLAS_TOKEN=?? # use secure:
 
-install:
+before_install:
+  - sudo apt-get update
   - sudo apt-get install virtualbox
+
+install:
   - wget --no-check-certificate --output-document packer.zip $PACKER_DOWNLOAD/packer_0.8.2_linux_amd64.zip
   - unzip -d packer packer.zip
   - export PATH=$PATH:$PWD/packer


### PR DESCRIPTION
The file is missing the needed encrypted atlas token, and the targets of the upload need to be targeting whatever the packer build creates. Apart from that, the build seems to be working as expected (though it's currently failing).
